### PR TITLE
bytedevkit-stm32mp1: Fix branch name for kernel

### DIFF
--- a/docs/source/yocto/3.1/bytedevkit-stm32mp1.rst
+++ b/docs/source/yocto/3.1/bytedevkit-stm32mp1.rst
@@ -308,7 +308,7 @@ Download the Linux Kernel
       - Branch
       - git URL
     * - bytedevkit-stm32mp1
-      - v5.4-stm32mp
+      - baw-v5.4-stm32mp
       - https://github.com/bytesatwork/linux-stm32mp.git
 
 ----


### PR DESCRIPTION
A wrong branch name slipped in during a previous upgrade. Mention the
correct branch name now.